### PR TITLE
Return Kafka Message as Response

### DIFF
--- a/internal/gofka/consumer/SyncConsumer.go
+++ b/internal/gofka/consumer/SyncConsumer.go
@@ -1,48 +1,38 @@
 package consumer
 
 import (
-	"context"
+	"generic-gofka/internal/gofka/model"
 	"github.com/IBM/sarama"
-	"log"
 )
 
-type SyncConsumer struct {
-	sarama.ConsumerGroup
+type Handler struct {
+	Messages chan<- *model.KafkaMessage
 }
 
-type ConsumerHandler struct {
-	Channel chan string
-}
-
-func (h *ConsumerHandler) Setup(sarama.ConsumerGroupSession) error   { return nil }
-func (h *ConsumerHandler) Cleanup(sarama.ConsumerGroupSession) error { return nil }
-func (h *ConsumerHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+func (h Handler) Setup(sarama.ConsumerGroupSession) error   { return nil }
+func (h Handler) Cleanup(sarama.ConsumerGroupSession) error { return nil }
+func (h Handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for msg := range claim.Messages() {
-		log.Printf("Received message: Topic=%s, Partition=%d, Offset=%d, Key=%s, Value=%s\n",
-			msg.Topic, msg.Partition, msg.Offset, string(msg.Key), string(msg.Value))
-		h.Channel <- string(msg.Value)
+		kafkaMessage := model.KafkaMessage{
+			Topic:     msg.Topic,
+			Partition: msg.Partition,
+			Offset:    msg.Offset,
+			Key:       string(msg.Key),
+			Value:     string(msg.Value),
+		}
+
+		h.Messages <- &kafkaMessage
 		session.MarkMessage(msg, "")
 	}
 	return nil
 }
 
-func InitializeSyncConsumer(brokers []string, topics []string, groupID string) (*sarama.ConsumerGroup, error) {
+func InitializeSyncConsumer(brokers []string, groupID string) (sarama.ConsumerGroup, error) {
 	config := sarama.NewConfig()
-	consumer, err := sarama.NewConsumerGroup(brokers, groupID, config)
+	client, err := sarama.NewConsumerGroup(brokers, groupID, config)
 	if err != nil {
 		return nil, err
 	}
 
-	handler := &ConsumerHandler{}
-	go func() {
-		for _, topic := range topics {
-			err := consumer.Consume(context.Background(), []string{topic}, handler)
-			if err != nil {
-				log.Printf("Error consuming topic %s: %v\n", topic, err)
-				return
-			}
-		}
-	}()
-
-	return &consumer, nil
+	return client, nil
 }

--- a/internal/gofka/model/models.go
+++ b/internal/gofka/model/models.go
@@ -1,0 +1,9 @@
+package model
+
+type KafkaMessage struct {
+	Topic     string `json:"topic"`
+	Partition int32  `json:"partition"`
+	Offset    int64  `json:"offset"`
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+}


### PR DESCRIPTION
When posting messages to kafka through the http, return a kafka message object. The object is created when we are consuming the message from the ConsumeClaim, sending it through a channel, which is being read and send it back in the response as json.

Sample request and response:

```
curl -i --location 'localhost:9000/produce?key=123&value=test'
HTTP/1.1 200 OK
Date: Thu, 21 Mar 2024 21:48:01 GMT
Content-Length: 80
Content-Type: text/plain; charset=utf-8

{"topic":"gofka-topic","partition":0,"offset":42,"key":"thiago","value":"test"}
```